### PR TITLE
Types update

### DIFF
--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -29,6 +29,11 @@ interface ObjectAttributes extends Record<string, object | string | number | boo
   action: string;
   state: string;
   last_commit: Record<string, object | string | boolean>;
+  iid: number;
+  title: string;
+  url: string;
+  merge_status: string;
+  head_pipeline_id: number | null;
 }
 
 type MergeStatus = "unchecked" | "preparing" | "can_be_merged";

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -24,7 +24,7 @@ type UserRecord = {
   email: string,
 };
 
-interface ObjectAttributes extends Record<string, object | string | boolean> {
+interface ObjectAttributes extends Record<string, object | string | number | boolean | null> {
   source_branch: string;
   action: string;
   state: string;

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -28,6 +28,7 @@ interface ObjectAttributes extends Record<string, object | string | boolean> {
   source_branch: string;
   action: string;
   state: string;
+  last_commit: Record<string, object | string | boolean>;
 }
 
 type MergeStatus = "unchecked" | "preparing" | "can_be_merged";

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -30,6 +30,8 @@ interface ObjectAttributes extends Record<string, object | string | boolean> {
   state: string;
 }
 
+type MergeStatus = "unchecked" | "preparing" | "can_be_merged";
+
 export interface Payload extends Record<string, object | string> {
   object_kind: string;
   event_type: string;

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -44,6 +44,10 @@ export interface Payload extends Record<string, object | string> {
     last_edited_at?: PreviousCurrentRecord<string>;
     updated_at?: PreviousCurrentRecord<string>;
     labels?: PreviousCurrentRecord<Label[]>;
+    merge_status?: PreviousCurrentRecord<MergeStatus | string>;
+    title?: PreviousCurrentRecord<string>;
+    state_id?: PreviousCurrentRecord<number>;
+    updated_by_id?: PreviousCurrentRecord<number>;
   };
   repository: Record<string, string>;
   assignees: UserRecord[];

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -16,6 +16,10 @@ type Label = {
   group_id: number | null,
 };
 
+interface Project extends Record<string, string> {
+  path_with_namespace: string,
+}
+
 type UserRecord = {
   id: number,
   name: string,
@@ -42,7 +46,7 @@ export interface Payload extends Record<string, object | string> {
   object_kind: string;
   event_type: string;
   user: UserRecord;
-  project: Record<string, string>;
+  project: Project;
   object_attributes: ObjectAttributes;
   labels: Label[],
   changes: {

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -20,7 +20,7 @@ interface Project extends Record<string, string> {
   path_with_namespace: string,
 }
 
-type UserRecord = {
+type User = {
   id: number,
   name: string,
   username: string,
@@ -45,7 +45,7 @@ type MergeStatus = "unchecked" | "preparing" | "can_be_merged";
 export interface Payload extends Record<string, object | string> {
   object_kind: string;
   event_type: string;
-  user: UserRecord;
+  user: User;
   project: Project;
   object_attributes: ObjectAttributes;
   labels: Label[],
@@ -60,8 +60,8 @@ export interface Payload extends Record<string, object | string> {
     updated_by_id?: PreviousCurrentRecord<number>;
   };
   repository: Record<string, string>;
-  assignees: UserRecord[];
-  reviewers: UserRecord[];
+  assignees: User[];
+  reviewers: User[];
 }
 
 export interface MergeRequestPayload extends Payload {


### PR DESCRIPTION
Various types update after inspecting payloads. This types update is likely never ending. So merging when there's a bunch of them already.

Tried to use types from `@gitbeaker/rest` but they don't have types for event payloads. rather types for rest api responses.