### PR TITLE
Add generic EventLogger logger

### DIFF
--- a/demo/src/EventLogger.ts
+++ b/demo/src/EventLogger.ts
@@ -1,0 +1,29 @@
+import { BaseHandler, Event, Handler } from "../../src";
+import { EVENT_TYPES } from "../../src/types";
+
+export class EventLogger extends BaseHandler implements Handler {
+  public event_types = [EVENT_TYPES.ANY];
+  public async handle(event: Event): Promise<void> {
+    const {
+      headers: {
+        "x-gitlab-event-uuid": event_uuid,
+      },
+      payload: {
+        event_type,
+        object_kind,
+        user,
+      },
+    } = event;
+
+    const {
+      name: user_name,
+      username: user_handle,
+    } = user || {};
+
+    this.logger.debug(`Received ${event_type || object_kind} event ${event_uuid} by @${user_handle} (${user_name})`);
+  }
+
+  public isValid(): boolean {
+    return true;
+  }
+}

--- a/demo/src/demo.ts
+++ b/demo/src/demo.ts
@@ -1,9 +1,11 @@
 import { logger, main } from "../../src";
 import { RenovateRebase } from "./RenovateRebase";
+import { EventLogger } from "./EventLogger";
 
 main({
   logger,
   handlers: [
+    new EventLogger(logger),
     new RenovateRebase(logger),
   ],
 });

--- a/src/handlers/HandlerRegistry.ts
+++ b/src/handlers/HandlerRegistry.ts
@@ -1,5 +1,6 @@
 import { Handler } from "./Handler";
 import { LoggerInterface } from "../services/logger";
+import { EVENT_TYPES } from "../types";
 
 export class HandlerRegistry {
   private handlers: Record<string, Handler[]> = {};
@@ -10,7 +11,10 @@ export class HandlerRegistry {
   }
 
   public getHandlersByEventType(event_type: string) {
-      return Object.values(this.handlers[event_type] || []);
+    return new Set([
+      this.handlers[event_type] || [],
+      this.handlers[EVENT_TYPES.ANY] || [],
+    ].flat());
   }
 
   public addHandlers(handlers: Handler[]): void {

--- a/src/handlers/WebHookHandler.ts
+++ b/src/handlers/WebHookHandler.ts
@@ -20,17 +20,6 @@ export class WebHookHandler {
       return;
     }
 
-    const {
-      event_type,
-      object_kind,
-      user,
-    } = event.payload;
-    const {
-      name: user_name,
-      username: user_handle,
-    } = user || {};
-
-    this.logger.debug(`Received ${event_type || object_kind} event ${event_uuid} by @${user_handle} (${user_name})`);
     this.queue.put(event);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type Event<P = any> = {
 }
 
 export enum EVENT_TYPES {
+  ANY = "any",
   DEPLOYMENT = "deployment",
   MERGE_REQUEST = "merge_request",
 }


### PR DESCRIPTION
This removes this logic from default WebHookHandler leaving it clean and error free.