### PR TITLE
Increase body size 100k to 5mb

### DIFF
--- a/src/services/httpServer.ts
+++ b/src/services/httpServer.ts
@@ -8,7 +8,7 @@ const port = 3000;
 const prefix = "/";
 const url = new URL(`http://localhost:${port}${prefix}`);
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: "5mb" }));
 app.use(prefix, routes);
 app.set("prefix", prefix);
 app.set("port", port);


### PR DESCRIPTION
> PayloadTooLargeError: request entity too large
>     at readStream (/app/node_modules/raw-body/index.js:163:17)
>     at getRawBody (/app/node_modules/raw-body/index.js:116:12)
>     at read (/app/node_modules/body-parser/lib/read.js:79:3)
>     at jsonParser (/app/node_modules/body-parser/lib/types/json.js:138:5)
>     at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
>     at trim_prefix (/app/node_modules/express/lib/router/index.js:328:13)
>     at /app/node_modules/express/lib/router/index.js:286:9
>     at Function.process_params (/app/node_modules/express/lib/router/index.js:346:12)
>     at next (/app/node_modules/express/lib/router/index.js:280:10)
>     at expressInit (/app/node_modules/express/lib/middleware/init.js:40:5)

- https://stackoverflow.com/questions/19917401/error-request-entity-too-large/19965089#19965089