### PR TITLE
Validate incoming headers

### DIFF
--- a/src/core/WebHookHandler.ts
+++ b/src/core/WebHookHandler.ts
@@ -15,16 +15,6 @@ export class WebHookHandler {
   }
 
   public async handle(event: Event): Promise<void> {
-    const {
-      "x-gitlab-event": event_name,
-      "x-gitlab-event-uuid": event_uuid,
-    } = event.headers;
-
-    if (!event_name || !event_uuid) {
-      this.logger.debug("No X-Gitlab-Event or X-Gitlab-Event-UUID header");
-      return;
-    }
-
     this.queue.put(event);
   }
 }

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -38,6 +38,7 @@ export default async ({ body: payload, headers: incoming_headers }: Request, res
     res.send("ok\n");
   } catch (e: any) {
     registry.logger.error(e.message);
+    res.status(500);
     res.send("err\n");
   }
 };

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -1,11 +1,40 @@
 import { Request, Response } from "express";
 import webhook from "../services/webhook";
 import registry from "../services/registry";
+import { Headers } from "../types";
+
+const required_headers = [
+  "user-agent",
+  "x-gitlab-event",
+  "x-gitlab-event-uuid",
+  "x-gitlab-instance",
+  "x-gitlab-webhook-uuid",
+];
+
+const validate_headers = (headers: Request["headers"]): Headers => {
+  const missing: string[] = [];
+
+  for (const key of required_headers) {
+    if (!headers[key] || typeof headers[key] !== "string") {
+      missing.push(key);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error("Missing or invalid required headers: " + missing.join(", "));
+  }
+
+  return headers as Headers;
+}
 
 // Listener for GitLab WebHooks
-export default async ({ body: payload, headers }: Request, res: Response) => {
+export default async ({ body: payload, headers: incoming_headers }: Request, res: Response) => {
   try {
-    await webhook.handle({headers, payload});
+    const headers = validate_headers(incoming_headers)
+    await webhook.handle({
+      headers,
+      payload,
+    });
     res.send("ok\n");
   } catch (e: any) {
     registry.logger.error(e.message);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { Request } from "express";
 
 // https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#delivery-headers
-type Headers = Request["headers"] & {
+export type Headers = Request["headers"] & {
   "user-agent": string;
   "x-gitlab-event": string;
   "x-gitlab-event-uuid": string;


### PR DESCRIPTION
The types are incompatible otherwise

```

$ tsc
src/routes/webhook.ts:8:27 - error TS2322: Type 'IncomingHttpHeaders' is not assignable to type 'Headers'.
  Type 'IncomingHttpHeaders' is missing the following properties from type '{ "user-agent": string; "x-gitlab-event": string; "x-gitlab-event-uuid": string; "x-gitlab-instance": string; "x-gitlab-webhook-uuid": string; }': "x-gitlab-event", "x-gitlab-event-uuid", "x-gitlab-instance", "x-gitlab-webhook-uuid"

8     await webhook.handle({headers, payload});
                            ~~~~~~~

  src/types.ts:13:3
    13   headers: Headers;
         ~~~~~~~
    The expected type comes from property 'headers' which is declared here on type 'Event'


Found 1 error in src/routes/webhook.ts:8

```

- https://github.com/glensc/gitlab-webhook-listener-bot/actions/runs/6224876965/job/16894059837