### PR TITLE
Refactor: Rename Event->WebhookEvent

### DIFF
--- a/demo/src/EventLogger.ts
+++ b/demo/src/EventLogger.ts
@@ -1,7 +1,7 @@
-import { BaseHandler, Event } from "../../src";
+import { BaseHandler, WebhookEvent } from "../../src";
 
 export class EventLogger extends BaseHandler {
-  public async handle(event: Event): Promise<void> {
+  public async handle(event: WebhookEvent): Promise<void> {
     const {
       headers: {
         "x-gitlab-event-uuid": event_uuid,

--- a/demo/src/ProjectCreateEvent.ts
+++ b/demo/src/ProjectCreateEvent.ts
@@ -1,9 +1,9 @@
-import { BaseHandler, Event, EVENT_TYPES, ProjectCreatePayload } from "../../src";
+import { BaseHandler, WebhookEvent, EVENT_TYPES, ProjectCreatePayload } from "../../src";
 
 export class ProjectCreateEvent extends BaseHandler {
   public event_types = [EVENT_TYPES.PROJECT_CREATE];
 
-  public async handle({ payload }: Event<ProjectCreatePayload>): Promise<void> {
+  public async handle({ payload }: WebhookEvent<ProjectCreatePayload>): Promise<void> {
     const {
       path_with_namespace,
     } = payload;

--- a/demo/src/RenovateRebase.ts
+++ b/demo/src/RenovateRebase.ts
@@ -1,7 +1,7 @@
-import { Event, MergeRequestHandler, MergeRequestPayload } from "../../src";
+import { WebhookEvent, MergeRequestHandler, MergeRequestPayload } from "../../src";
 
 export class RenovateRebase extends MergeRequestHandler {
-  public async handle(event: Event<MergeRequestPayload>): Promise<void> {
+  public async handle(event: WebhookEvent<MergeRequestPayload>): Promise<void> {
     this.logger.debug("Renovate bot wants rebase");
     // TODO: create pipeline
     // code here to do the actual action
@@ -12,7 +12,7 @@ export class RenovateRebase extends MergeRequestHandler {
    * and branch is renovate branch
    * and rebase checkbox is checked.
    */
-  public isValid({ payload }: Event<MergeRequestPayload>): boolean {
+  public isValid({ payload }: WebhookEvent<MergeRequestPayload>): boolean {
     const {
       object_attributes: {
         source_branch,

--- a/src/core/BaseHandler.ts
+++ b/src/core/BaseHandler.ts
@@ -1,5 +1,5 @@
 import { LoggerInterface } from "../services/logger";
-import { Event, EVENT_TYPES } from "../types";
+import { WebhookEvent, EVENT_TYPES } from "../types";
 import { Handler } from "./Handler";
 
 export abstract class BaseHandler<P = any> implements Handler {
@@ -10,6 +10,6 @@ export abstract class BaseHandler<P = any> implements Handler {
   ) {
   }
 
-  public abstract isValid(event: Event<P>): boolean;
-  public abstract handle(event: Event<P>): Promise<void>;
+  public abstract isValid(event: WebhookEvent<P>): boolean;
+  public abstract handle(event: WebhookEvent<P>): Promise<void>;
 }

--- a/src/core/Handler.ts
+++ b/src/core/Handler.ts
@@ -1,7 +1,7 @@
-import { Event, EVENT_TYPES } from "../types";
+import { WebhookEvent, EVENT_TYPES } from "../types";
 
 export interface Handler {
   event_types: EVENT_TYPES[];
-  isValid(event: Event): boolean;
-  handle(event: Event): Promise<void>;
+  isValid(event: WebhookEvent): boolean;
+  handle(event: WebhookEvent): Promise<void>;
 }

--- a/src/core/WebHookHandler.ts
+++ b/src/core/WebHookHandler.ts
@@ -1,5 +1,5 @@
 import { Queue } from "../queue/Queue";
-import { Event } from "../types";
+import { WebhookEvent } from "../types";
 import { LoggerInterface } from "../services/logger";
 import { Registry } from "./Registry";
 
@@ -14,7 +14,7 @@ export class WebHookHandler {
     return this.registry.logger;
   }
 
-  public async handle(event: Event): Promise<void> {
+  public async handle(event: WebhookEvent): Promise<void> {
     this.queue.put(event);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export { default as logger } from "./services/logger";
 // Reusable classes and types
 export type { Handler } from "./core/Handler"
 export type { LoggerInterface } from "./services/logger";
-export type { Event } from "./types";
+export type { WebhookEvent } from "./types";
 export { EVENT_TYPES } from "./types";
 export { BaseHandler } from "./core/BaseHandler";
 export * from "./payload";

--- a/src/queue/Queue.ts
+++ b/src/queue/Queue.ts
@@ -1,6 +1,6 @@
-import { Event } from "../types";
+import { WebhookEvent } from "../types";
 
-export class Queue<T = Event> {
+export class Queue<T = WebhookEvent> {
   private readonly q: T[] = [];
 
   public put(event: T) {

--- a/src/queue/QueueWorker.ts
+++ b/src/queue/QueueWorker.ts
@@ -1,7 +1,7 @@
 import { setTimeout } from "node:timers/promises";
 import { Queue } from "./Queue";
 import { LoggerInterface } from "../services/logger";
-import { Event } from "../types";
+import { WebhookEvent } from "../types";
 import { HandlerRegistry } from "../core/HandlerRegistry";
 import { Registry } from "../core/Registry";
 
@@ -34,7 +34,7 @@ export class QueueWorker {
     }
   }
 
-  private async handle(event: Event) {
+  private async handle(event: WebhookEvent) {
     const {
       event_type,
       object_kind,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type Headers = Request["headers"] & {
   "x-gitlab-webhook-uuid": string;
 };
 
-export type Event<P = any> = {
+export type WebhookEvent<P = any> = {
   headers: Headers;
   payload: P;
 }


### PR DESCRIPTION
This is to avoid resolving to global Event in case of missing import