### PR TITLE
Add livenessProbe, readinessProbe options

### DIFF
--- a/demo/src/demo.ts
+++ b/demo/src/demo.ts
@@ -10,4 +10,10 @@ main({
     new ProjectCreateEvent(logger),
     new RenovateRebase(logger),
   ],
+  livenessProbe() {
+    logger.debug("Called livenessProbe");
+  },
+  readinessProbe() {
+    logger.debug("Called readinessProbe");
+  },
 });

--- a/src/core/Registry.ts
+++ b/src/core/Registry.ts
@@ -1,16 +1,26 @@
 import { LoggerInterface } from "../services/logger";
+import { ProbeHandler } from "../types";
+
+interface RegistryInterface {
+  logger: LoggerInterface;
+}
 
 export class Registry {
+  private readonly registry = new Map<keyof RegistryInterface, any>();
+
   public constructor(
-    private _logger: LoggerInterface,
+    registry: RegistryInterface,
   ) {
+    for (const [key, value] of Object.entries(registry)) {
+      this.registry.set(key as keyof RegistryInterface, value);
+    }
   }
 
   public set logger(logger: LoggerInterface) {
-    this._logger = logger;
+    this.registry.set("logger", logger);
   }
 
   public get logger(): LoggerInterface {
-    return this._logger;
+    return this.registry.get("logger");
   }
 }

--- a/src/core/Registry.ts
+++ b/src/core/Registry.ts
@@ -3,6 +3,8 @@ import { ProbeHandler } from "../types";
 
 interface RegistryInterface {
   logger: LoggerInterface;
+  livenessProbe: ProbeHandler;
+  readinessProbe: ProbeHandler;
 }
 
 export class Registry {
@@ -22,5 +24,21 @@ export class Registry {
 
   public get logger(): LoggerInterface {
     return this.registry.get("logger");
+  }
+
+  public set livenessProbe(probe: ProbeHandler) {
+    this.registry.set("livenessProbe", probe);
+  }
+
+  public get livenessProbe(): ProbeHandler {
+    return this.registry.get("livenessProbe");
+  }
+
+  public set readinessProbe(probe: ProbeHandler) {
+    this.registry.set("readinessProbe", probe);
+  }
+
+  public get readinessProbe(): ProbeHandler {
+    return this.registry.get("readinessProbe");
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,10 +11,11 @@ type Options = {
   logger: LoggerInterface,
 };
 
-export const main = ({
-                       logger,
-                       handlers,
-                     }: Options): void => {
+export const main = (options: Options): void => {
+  const {
+    logger,
+    handlers,
+  } = options;
 
   registry.logger = logger;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,19 +5,30 @@ import { urlPath } from "./urlPath";
 import handlerRegister from "./services/handlers";
 import worker from "./services/worker";
 import registry from "./services/registry";
+import { ProbeHandler } from "./types";
 
 type Options = {
   handlers?: Handler[],
   logger: LoggerInterface,
+  livenessProbe?: ProbeHandler,
+  readinessProbe?: ProbeHandler,
 };
 
 export const main = (options: Options): void => {
   const {
     logger,
     handlers,
+    livenessProbe,
+    readinessProbe,
   } = options;
 
   registry.logger = logger;
+  if (livenessProbe) {
+    registry.livenessProbe = livenessProbe;
+  }
+  if (readinessProbe) {
+    registry.readinessProbe = readinessProbe;
+  }
 
   if (handlers) {
     handlerRegister.addHandlers(handlers);

--- a/src/routes/probes.ts
+++ b/src/routes/probes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import registry from "../services/registry";
 
 const router = Router();
 
@@ -7,12 +8,24 @@ const router = Router();
 // liveness probes could catch a deadlock, where an application is running, but unable to make progress.
 // Restarting a container in such a state can help to make the application more available despite bugs.
 router.get("/liveness", (req, res) => {
-  res.status(200).send("ok\n");
+  try {
+    registry.livenessProbe();
+    res.status(200).send("ok\n");
+  } catch (err) {
+    registry.logger.error(err);
+    res.status(500).send("err\n");
+  }
 });
 
 // pod is ready to accept traffic
 router.get("/readiness", (req, res) => {
-  res.status(200).send("ok\n");
+  try {
+    registry.readinessProbe();
+    res.status(200).send("ok\n");
+  } catch (err) {
+    registry.logger.error(err);
+    res.status(500).send("err\n");
+  }
 });
 
 export default router;

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -1,4 +1,6 @@
 import { Registry } from "../core/Registry";
 import logger from "./logger";
 
-export default new Registry(logger);
+export default new Registry({
+  "logger": logger,
+});

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -1,6 +1,10 @@
 import { Registry } from "../core/Registry";
 import logger from "./logger";
 
+const noop = () => {};
+
 export default new Registry({
   "logger": logger,
+  "livenessProbe": noop,
+  "readinessProbe": noop,
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export type WebhookEvent<P = any> = {
   payload: P;
 }
 
+export type ProbeHandler = () => void;
+
 export enum EVENT_TYPES {
   ANY = "any",
   DEPLOYMENT = "deployment",


### PR DESCRIPTION
This allows to setup your own handlers for those probes. Defaults to function that does nothing.

```ts

main({
  // ...
  livenessProbe() {
    logger.debug("Called livenessProbe");
  },
  readinessProbe() {
    logger.debug("Called readinessProbe");
  },
});

```