### PR TITLE
Refactor: Make ProbeHandlers async

### DIFF
--- a/demo/src/demo.ts
+++ b/demo/src/demo.ts
@@ -10,10 +10,10 @@ main({
     new ProjectCreateEvent(logger),
     new RenovateRebase(logger),
   ],
-  livenessProbe() {
+  async livenessProbe() {
     logger.debug("Called livenessProbe");
   },
-  readinessProbe() {
+  async readinessProbe() {
     logger.debug("Called readinessProbe");
   },
 });

--- a/src/routes/probes.ts
+++ b/src/routes/probes.ts
@@ -10,7 +10,7 @@ const router = Router();
 // Restarting a container in such a state can help to make the application more available despite bugs.
 router.get("/liveness", asyncHandler(async (req, res) => {
   try {
-    registry.livenessProbe();
+    await registry.livenessProbe();
     res.status(200).send("ok\n");
   } catch (err) {
     registry.logger.error(err);
@@ -21,7 +21,7 @@ router.get("/liveness", asyncHandler(async (req, res) => {
 // pod is ready to accept traffic
 router.get("/readiness", asyncHandler(async (req, res) => {
   try {
-    registry.readinessProbe();
+    await registry.readinessProbe();
     res.status(200).send("ok\n");
   } catch (err) {
     registry.logger.error(err);

--- a/src/routes/probes.ts
+++ b/src/routes/probes.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import registry from "../services/registry";
+import { asyncHandler } from "../util";
 
 const router = Router();
 
@@ -7,7 +8,7 @@ const router = Router();
 
 // liveness probes could catch a deadlock, where an application is running, but unable to make progress.
 // Restarting a container in such a state can help to make the application more available despite bugs.
-router.get("/liveness", (req, res) => {
+router.get("/liveness", asyncHandler(async (req, res) => {
   try {
     registry.livenessProbe();
     res.status(200).send("ok\n");
@@ -15,10 +16,10 @@ router.get("/liveness", (req, res) => {
     registry.logger.error(err);
     res.status(500).send("err\n");
   }
-});
+}));
 
 // pod is ready to accept traffic
-router.get("/readiness", (req, res) => {
+router.get("/readiness", asyncHandler(async (req, res) => {
   try {
     registry.readinessProbe();
     res.status(200).send("ok\n");
@@ -26,6 +27,6 @@ router.get("/readiness", (req, res) => {
     registry.logger.error(err);
     res.status(500).send("err\n");
   }
-});
+}));
 
 export default router;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export type WebhookEvent<P = any> = {
   payload: P;
 }
 
-export type ProbeHandler = () => void;
+export type ProbeHandler = () => Promise<void>;
 
 export enum EVENT_TYPES {
   ANY = "any",

--- a/src/util/asyncHandler.ts
+++ b/src/util/asyncHandler.ts
@@ -1,0 +1,8 @@
+import type { NextFunction, Request, Response } from "express";
+
+type FunctionType = (req: Request, res: Response, next: NextFunction) => Promise<void>;
+
+// https://stackoverflow.com/questions/61086833/async-await-in-express-middleware/65074524#65074524
+export const asyncHandler = (fn: FunctionType) => (req: Request, res: Response, next: NextFunction): void => {
+  fn(req, res, next).catch(next);
+};

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,1 +1,2 @@
+export { asyncHandler } from "./asyncHandler"
 export { urlPath } from "./urlPath"


### PR DESCRIPTION
The code you usually want to call from probes is likely async and making external connections.