### PR TITLE
Make default noop handler async

### DIFF
--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -1,7 +1,7 @@
 import { Registry } from "../core/Registry";
 import logger from "./logger";
 
-const noop = () => {};
+const noop = async (): Promise<void> => {};
 
 export default new Registry({
   "logger": logger,


### PR DESCRIPTION
```
$ tsc
src/services/registry.ts:8:3 - error TS2322: Type '() => void' is not assignable to type 'ProbeHandler'.
  Type 'void' is not assignable to type 'Promise<void>'.

8   "livenessProbe": noop,
    ~~~~~~~~~~~~~~~

  src/core/Registry.ts:6:3
    6   livenessProbe: ProbeHandler;
        ~~~~~~~~~~~~~
    The expected type comes from property 'livenessProbe' which is declared here on type 'RegistryInterface'

src/services/registry.ts:9:3 - error TS23[22](https://github.com/glensc/gitlab-webhook-listener-bot/actions/runs/6397372174/job/17365158227#step:6:23): Type '() => void' is not assignable to type 'ProbeHandler'.

9   "readinessProbe": noop,
    ~~~~~~~~~~~~~~~~

  src/core/Registry.ts:7:3
    7   readinessProbe: ProbeHandler;
        ~~~~~~~~~~~~~~
    The expected type comes from property 'readinessProbe' which is declared here on type 'RegistryInterface'


Found 2 errors in the same file, starting at: src/services/registry.ts:8

error Command failed with exit code 2.
```

- https://github.com/glensc/gitlab-webhook-listener-bot/actions/runs/6397372174/job/17365158227#step:6:20