### PR TITLE
Set --no-git-checks for pnpm publish

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -40,7 +40,7 @@ jobs:
           APP_VERSION: ${{ steps.vars.outputs.version }}
 
       - name: Publish
-        run: pnpm publish --access public
+        run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
>  ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.
>
> If you want to disable Git checks on publish, set the "git-checks"
> setting to "false", or run again with "--no-git-checks".

- https://github.com/glensc/gitlab-webhook-listener-bot/actions/runs/6686243166/job/18165384134#step:7:9

Refs:
- https://pnpm.io/cli/publish