### PR TITLE
Fix inferred types error

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,7 +3,7 @@ import main from "./main";
 import webhook from "./webhook";
 import probes from "./probes";
 
-const router = Router();
+const router: Router = Router();
 
 router.get("/", main);
 router.use("/probes", probes);

--- a/src/routes/probes.ts
+++ b/src/routes/probes.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import registry from "../services/registry";
 import { asyncHandler } from "../util";
 
-const router = Router();
+const router: Router = Router();
 
 // https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 

--- a/src/services/httpServer.ts
+++ b/src/services/httpServer.ts
@@ -1,9 +1,9 @@
 import bodyParser from "body-parser";
-import express from "express";
+import express, { Express } from "express";
 
 import routes from "../routes";
 
-const app = express();
+const app: Express = express();
 const port = 3000;
 const prefix = "/";
 const url = new URL(`http://localhost:${port}${prefix}`);


### PR DESCRIPTION
```
$ tsc
src/routes/index.ts:6:7 - error TS2742: The inferred type of 'router' cannot be named without a reference to
'.pnpm/@types+express-serve-static-core@4.17.39/node_modules/@types/express-serve-static-core'. This is likely not portable. A type annotation is necessary.

6 const router = Router();
        ~~~~~~

src/routes/probes.ts:5:7 - error TS2742: The inferred type of 'router' cannot be named without a reference to
'.pnpm/@types+express-serve-static-core@4.17.39/node_modules/@types/express-serve-static-core'. This is likely not portable. A type annotation is necessary.

5 const router = Router();
        ~~~~~~

src/services/httpServer.ts:6:7 - error TS2742: The inferred type of 'app' cannot be named without a reference to
'.pnpm/@types+express-serve-static-core@4.17.39/node_modules/@types/express-serve-static-core'. This is likely not portable. A type annotation is necessary.

6 const app = express();
        ~~~

Found 3 errors in 3 files.

Errors  Files
     1  src/routes/index.ts:6
     1  src/routes/probes.ts:5
     1  src/services/httpServer.ts:6
```

Broken from 47f81e02d20bd1cb61d52cc894ce5b1591f7c34f