### PR TITLE
Make GitlabClient.api protected

### DIFF
--- a/src/gitlab/GitlabClient.ts
+++ b/src/gitlab/GitlabClient.ts
@@ -1,7 +1,7 @@
 import { Gitlab } from "@gitbeaker/rest";
 
 export class GitlabClient {
-  private readonly api: InstanceType<typeof Gitlab<false>>;
+  protected readonly api: InstanceType<typeof Gitlab<false>>;
 
   public constructor(
     host: string,


### PR DESCRIPTION
Allow class to be extended by downstream projects.