### PR TITLE
Feature: Add MergeRequestObjectAttributes action definition

### DIFF
--- a/src/payload/merge_request/MergeRequestObjectAttributes.ts
+++ b/src/payload/merge_request/MergeRequestObjectAttributes.ts
@@ -4,6 +4,8 @@ import type { ObjectAttributes } from "../ObjectAttributes";
 import type { Project } from "../Project";
 
 export interface MergeRequestObjectAttributes extends ObjectAttributes {
+  // https://docs.gitlab.com/user/project/integrations/webhook_events/#payload-structure
+  action?: "open" | "close" | "reopen" | "update" | "approval" | "approved" | "unapproval" | "unapproved" | "merge";
   draft: boolean;
   head_pipeline_id: number | null;
   merge_commit_sha: string | null;


### PR DESCRIPTION
Add concrete values for merge request object_attributes from documentation:
- https://docs.gitlab.com/user/project/integrations/webhook_events/#payload-structure