### PR TITLE
Fix: Update npm workflow permissions for trusted publishing

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "*.*.*"
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -41,7 +45,5 @@ jobs:
 
       - name: Publish
         run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 # vim:ft=yaml:et:ts=2:sw=2


### PR DESCRIPTION
Added permissions for contents and id-token in workflow.